### PR TITLE
fix: Export the `Render` type

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -10,7 +10,7 @@ export {
 } from './renderStream/createRenderStream.js'
 export {useTrackRenders} from './renderStream/useTrackRenders.js'
 
-export type {SyncScreen} from './renderStream/Render.js'
+export type {Render, SyncScreen} from './renderStream/Render.js'
 
 export {renderHookToSnapshotStream} from './renderHookToSnapshotStream.js'
 export type {SnapshotStream} from './renderHookToSnapshotStream.js'


### PR DESCRIPTION
While creating a [helper](https://github.com/apollographql/apollo-client/pull/12993/files#diff-b6714be1287aead313134d16e444b798456ccd837eff725ecaff96dac68d8035) to render suspense hooks, I encountered a TypeScript error when trying to return `takeRender` from the helper ([source](https://app.circleci.com/pipelines/github/apollographql/apollo-client/30611/workflows/4e539e6a-5a33-4cd6-9e8d-4396b46da16c/jobs/335193)):

```
Return type of exported function has or is using name 'Render' from external module "/home/circleci/project/node_modules/@testing-library/react-render-stream/dist/pure" but cannot be named.
```

This fixes the TypeScript issue as demonstrated in the [patch](https://github.com/apollographql/apollo-client/pull/12993/commits/1db3a3611befb5b176c32a87c6600628bb09ed04).